### PR TITLE
chore(dev): add .agents submodule with AI skills

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".agents"]
+	path = .agents
+	url = https://github.com/xenoterracide/subtree-ai.git

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,6 +4,10 @@
 
 version = 1
 [[annotations]]
+path = ".gitmodules"
+SPDX-FileCopyrightText = "NONE"
+SPDX-License-Identifier = "CC0-1.0"
+[[annotations]]
 path = "**/*.lockfile"
 SPDX-FileCopyrightText = "NONE"
 SPDX-License-Identifier = "CC0-1.0"


### PR DESCRIPTION
Add the .agents submodule pointing to subtree-ai repository to provide
standardized AI skills for the project.

- Add .agents submodule with AI skills for commit messages, PR handling,
  Gradle, Java, shell scripts, and use case documentation
- Add MCP configuration file with license
- Update REUSE.toml to include .gitmodules as CC0-1.0

Co-authored-by: Kimi <kimi@moonshot.localhost>