### PR TITLE
ci(renovate): pin only xenoterracide actions to commit SHAs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,13 @@
     },
     {
       matchManagers: ["github-actions"],
+      automerge: true,
+    },
+    {
+      // Pin xenoterracide org actions to commit SHAs for build reproducibility
+      // Only these get digest pins; other actions get normal version tag updates
+      matchManagers: ["github-actions"],
+      matchDepNames: ["xenoterracide/**"],
       extends: ["helpers:pinGitHubActionDigests"],
       automerge: true,
     },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: 24
           package-manager-cache: false
       - run: corepack enable
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: 24
           cache: "yarn"


### PR DESCRIPTION
Refine GitHub Actions digest pinning to only apply to xenoterracide
organization actions for build reproducibility. Other actions like
actions/setup-node will now use normal version tag updates instead of
commit SHA pins.

This change:
- Adds a separate rule for xenoterracide/** actions with digest pinning
- Removes digest pinning from general github-actions automerge rule
- Updates test.yml to use version tags instead of commit SHAs