### PR TITLE
ci: use semantic version tags and add --admin flag to merge command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.3.0
         with:
           node-version: 24

--- a/node/packages/merge/merge.ts
+++ b/node/packages/merge/merge.ts
@@ -518,7 +518,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  defaultRunner.run("gh pr merge --squash --delete-branch");
+  defaultRunner.run("gh pr merge --squash --delete-branch --admin");
   process.exit(0);
 }
 


### PR DESCRIPTION
- Update actions/checkout to use semantic version tag @v6.0.2 instead of commit SHA
- Add --admin flag to gh pr merge command to allow admin override
